### PR TITLE
fix(deps): [sc-43819] Update pnpm action to use v9

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -19,7 +19,7 @@ runs:
         node-version: 18
     - uses: pnpm/action-setup@v2
       with:
-        version: 8
+        version: 9
         run_install: true
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}


### PR DESCRIPTION
_Shortcut:_ https://app.shortcut.com/summer/story/43819/fix-renovate-bot-metrics-for-pnpm-packages

## What

Fix pnpm outdated action

## Why

failing with this error:
<img width="851" height="495" alt="Screenshot 2025-08-07 at 4 02 37 PM" src="https://github.com/user-attachments/assets/f06dd46f-4138-42b1-ab2c-d9c3a489be97" />

## How

Update pnpm version from 8 to 9

## How to Test

Merge and see if this fixes things
