### PR TITLE
fix(ci): [sc-46492] update pnpm in renovate metrics job

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,9 +17,9 @@ runs:
     - uses: actions/setup-node@v3
       with:
         node-version: 18
-    - uses: pnpm/action-setup@v2
+    - uses: pnpm/action-setup@v4
       with:
-        version: 9
+        version: 10
         run_install: true
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}


### PR DESCRIPTION
_Shortcut:_

## What

Update to pnpm 10 

## Why

Fixes metrics

## How

- Update pnpm version
- Update pnpm version getter to one that throws an error if the package version of the package being operated on is different (I think this will make this fail loudly in the future)
  - https://github.com/pnpm/action-setup/releases/tag/v4.0.0
