### PR TITLE
fix(metrics): [sc-n/a] Remove hard coded version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -19,7 +19,6 @@ runs:
         node-version: 18
     - uses: pnpm/action-setup@v4
       with:
-        version: 10
         run_install: true
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}


### PR DESCRIPTION
Remove version specification for pnpm action setup

_Shortcut:_

## What

Remove hard coding of version

## Why

The pnpm install action can just get it from the package.json of the invoking package

## How

Removed a line from the GH action yml

## How to Test

Run in monorepo/server