### PR TITLE
fix(deps): [sc-49700] custom node-version input

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,12 +11,14 @@ inputs:
   working-directory:
     required: false
     default: .
+  node-version:
+    required: true
 runs:
   using: "composite"
   steps:
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v4
       with:
-        node-version: 18
+        node-version: ${{ inputs.node-version }}
     - uses: pnpm/action-setup@v4
       with:
         run_install: true

--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,8 @@ inputs:
     required: false
     default: .
   node-version:
-    required: true
+    required: false
+    default: '18'
 runs:
   using: "composite"
   steps:


### PR DESCRIPTION
_Shortcut:_

## What

Switch the node version to be allowed as an input, but defaulting to 18.

## Why

Trying to fix the missing dependency metrics on server and devbot
- Hardcoded node 18 caused pnpm 10 to silently produce empty output from `pnpm outdated --json` when run against projects requiring node 22+, resulting in NaN metrics sent to Datadog. Making node-version a required input forces every caller to explicitly declare the node version their project needs.

## How

Making node version customizable per package

## How to Test

This should be backwards compatible, using 18 as default. Server and devbot PRs are coming with their node version inputs:

https://github.com/simplifidev/server/pull/6839
https://github.com/simplifidev/summer-devbot/pull/985